### PR TITLE
Fix: 

### DIFF
--- a/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
+++ b/libraries/src/AWS.Lambda.Powertools.Logging/Internal/PowertoolsLogger.cs
@@ -247,7 +247,7 @@ internal sealed class PowertoolsLogger : ILogger
                 foreach (PropertyDescriptor propertyDescriptor in TypeDescriptor.GetProperties(values))
                 {
                     object obj = propertyDescriptor.GetValue(values);
-                    if (obj.GetType().Name.Contains("Anonymous"))
+                    if (obj is not null && obj.GetType().Name.Contains("Anonymous"))
                     {
                         dict.Add(propertyDescriptor.Name,ToDictionary(obj));
                     }


### PR DESCRIPTION
> Please provide the issue number

Issue number: #212

## Summary
When a property has a value null  in PowertoolsLogger, NullReferenceException is raised 

### Changes
Added a check for a nullability


### User experience

> Please share what the user experience looks like before and after this change

## Checklist

Please leave checklist items unchecked if they do not apply to your change.

* [ ] [Meets tenets criteria](https://docs.powertools.aws.dev/lambda/dotnet/tenets)
* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://github.com/aws-powertools/powertools-lambda-dotnet/blob/develop/.github/semantic.yml)


<details>
<summary>Is this a breaking change?</summary>

**RFC issue number**:

Checklist:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
